### PR TITLE
Remove shellcheck addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: bash
-addons:
-  apt:
-    sources:
-    - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-    - shellcheck
 notifications:
   email: true
 script:


### PR DESCRIPTION
Supposedly it's available by default now.

https://github.com/koalaman/shellcheck#travis-ci